### PR TITLE
split compile time and runtime envt, made tail recursive

### DIFF
--- a/backend/src/data/function.rs
+++ b/backend/src/data/function.rs
@@ -2,13 +2,19 @@ use std::{rc::Rc, cell::RefCell};
 use lispers_common::Symbol;
 
 use crate::prelude::*;
-use crate::env::Env;
+use crate::env::{Env, RTE};
 use super::{Value, Lambda};
 
 pub type NativeFn<S> = fn(Rc<RefCell<Env<S>>>, Vec<Value<S>>) -> Result<Value<S>>;
 
 #[derive(Clone)]
+pub struct Closure<S: Symbol> {
+  pub rte: Rc<RefCell<RTE<S>>>,
+  pub func: Function<S>,
+}
+
+#[derive(Clone)]
 pub enum Function<S: Symbol> {
-  NativeFn(NativeFn<S>),
-  Lambda(Lambda<S>),
+  NativeFn(Option<Rc<RefCell<RTE<S>>>>, NativeFn<S>),
+  Lambda(Option<Rc<RefCell<RTE<S>>>>, Lambda<S>),
 }

--- a/backend/src/data/function.rs
+++ b/backend/src/data/function.rs
@@ -10,11 +10,12 @@ pub type NativeFn<S> = fn(Rc<RefCell<Env<S>>>, Vec<Value<S>>) -> Result<Value<S>
 #[derive(Clone)]
 pub struct Closure<S: Symbol> {
   pub rte: Rc<RefCell<RTE<S>>>,
-  pub func: Function<S>,
+  pub func: Lambda<S>,
 }
 
 #[derive(Clone)]
 pub enum Function<S: Symbol> {
-  NativeFn(Option<Rc<RefCell<RTE<S>>>>, NativeFn<S>),
-  Lambda(Option<Rc<RefCell<RTE<S>>>>, Lambda<S>),
+  NativeFn(NativeFn<S>),
+  Lambda(Lambda<S>),
+  Closure(Rc<RefCell<RTE<S>>>, usize, RtOp<S>),
 }

--- a/backend/src/data/lambda.rs
+++ b/backend/src/data/lambda.rs
@@ -2,10 +2,10 @@ use lispers_common::Symbol;
 
 use crate::prelude::*;
 
-use std::{rc::Rc};
+//use std::{rc::Rc};
 
 #[derive(Clone)]
 pub struct Lambda<S: Symbol> {
   pub params: Vec<S>,
-  pub code: Rc<Op<S>>,
+  pub code: RtOp<S>,
 }

--- a/backend/src/data/lambda.rs
+++ b/backend/src/data/lambda.rs
@@ -1,9 +1,9 @@
 use lispers_common::Symbol;
 
-use super::Value;
+use crate::prelude::*;
 
 #[derive(Clone)]
 pub struct Lambda<S: Symbol> {
   pub params: Vec<S>,
-  pub body: Box<Value<S>>,
+  pub code: Box<Op<S>>,
 }

--- a/backend/src/data/lambda.rs
+++ b/backend/src/data/lambda.rs
@@ -2,8 +2,10 @@ use lispers_common::Symbol;
 
 use crate::prelude::*;
 
+use std::{rc::Rc};
+
 #[derive(Clone)]
 pub struct Lambda<S: Symbol> {
   pub params: Vec<S>,
-  pub code: Box<Op<S>>,
+  pub code: Rc<Op<S>>,
 }

--- a/backend/src/env/default.rs
+++ b/backend/src/env/default.rs
@@ -12,79 +12,79 @@ pub fn default_env<S, B>(interner: &mut StringInterner<B>) -> Env<S>
 
   env.define(
     interner.get_or_intern("+"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::iadd)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::iadd)),
   );
   env.define(
     interner.get_or_intern("-"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::isub)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::isub)),
   );
   env.define(
     interner.get_or_intern("*"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::imul)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::imul)),
   );
   env.define(
     interner.get_or_intern("/"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::idiv)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::idiv)),
   );
   env.define(
     interner.get_or_intern(".+"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::fadd)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::fadd)),
   );
   env.define(
     interner.get_or_intern(".-"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::fsub)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::fsub)),
   );
   env.define(
     interner.get_or_intern(".*"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::fmul)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::fmul)),
   );
   env.define(
     interner.get_or_intern("./"),
-    Value::Function(Function::NativeFn(None, primitives::arithmetic::fdiv)),
+    Value::Function(Function::NativeFn(primitives::arithmetic::fdiv)),
   );
   env.define(
     interner.get_or_intern("<"),
-    Value::Function(Function::NativeFn(None, primitives::comparison::ilt)),
+    Value::Function(Function::NativeFn(primitives::comparison::ilt)),
   );
   env.define(
     interner.get_or_intern("<="),
-    Value::Function(Function::NativeFn(None, primitives::comparison::ilte)),
+    Value::Function(Function::NativeFn(primitives::comparison::ilte)),
   );
   env.define(
     interner.get_or_intern(">="),
-    Value::Function(Function::NativeFn(None, primitives::comparison::igte)),
+    Value::Function(Function::NativeFn(primitives::comparison::igte)),
   );
   env.define(
     interner.get_or_intern(">"),
-    Value::Function(Function::NativeFn(None, primitives::comparison::igt)),
+    Value::Function(Function::NativeFn(primitives::comparison::igt)),
   );
   env.define(
     interner.get_or_intern(".<"),
-    Value::Function(Function::NativeFn(None, primitives::comparison::flt)),
+    Value::Function(Function::NativeFn(primitives::comparison::flt)),
   );
   env.define(
     interner.get_or_intern(".<="),
-    Value::Function(Function::NativeFn(None, primitives::comparison::flte)),
+    Value::Function(Function::NativeFn(primitives::comparison::flte)),
   );
   env.define(
     interner.get_or_intern(".>="),
-    Value::Function(Function::NativeFn(None, primitives::comparison::fgte)),
+    Value::Function(Function::NativeFn(primitives::comparison::fgte)),
   );
   env.define(
     interner.get_or_intern(".>"),
-    Value::Function(Function::NativeFn(None, primitives::comparison::fgt)),
+    Value::Function(Function::NativeFn(primitives::comparison::fgt)),
   );
   env.define(
     interner.get_or_intern("="),
-    Value::Function(Function::NativeFn(None, primitives::comparison::eq)),
+    Value::Function(Function::NativeFn(primitives::comparison::eq)),
   );
   env.define(
     interner.get_or_intern("!="),
-    Value::Function(Function::NativeFn(None, primitives::comparison::ne)),
+    Value::Function(Function::NativeFn(primitives::comparison::ne)),
   );
   env.define(
     interner.get_or_intern("exit"),
-    Value::Function(Function::NativeFn(None, primitives::proc::exit)),
+    Value::Function(Function::NativeFn(primitives::proc::exit)),
   );
 
   env

--- a/backend/src/env/default.rs
+++ b/backend/src/env/default.rs
@@ -12,79 +12,79 @@ pub fn default_env<S, B>(interner: &mut StringInterner<B>) -> Env<S>
 
   env.define(
     interner.get_or_intern("+"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::iadd)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::iadd)),
   );
   env.define(
     interner.get_or_intern("-"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::isub)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::isub)),
   );
   env.define(
     interner.get_or_intern("*"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::imul)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::imul)),
   );
   env.define(
     interner.get_or_intern("/"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::idiv)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::idiv)),
   );
   env.define(
     interner.get_or_intern(".+"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::fadd)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::fadd)),
   );
   env.define(
     interner.get_or_intern(".-"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::fsub)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::fsub)),
   );
   env.define(
     interner.get_or_intern(".*"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::fmul)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::fmul)),
   );
   env.define(
     interner.get_or_intern("./"),
-    Value::Function(Function::NativeFn(primitives::arithmetic::fdiv)),
+    Value::Function(Function::NativeFn(None, primitives::arithmetic::fdiv)),
   );
   env.define(
     interner.get_or_intern("<"),
-    Value::Function(Function::NativeFn(primitives::comparison::ilt)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::ilt)),
   );
   env.define(
     interner.get_or_intern("<="),
-    Value::Function(Function::NativeFn(primitives::comparison::ilte)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::ilte)),
   );
   env.define(
     interner.get_or_intern(">="),
-    Value::Function(Function::NativeFn(primitives::comparison::igte)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::igte)),
   );
   env.define(
     interner.get_or_intern(">"),
-    Value::Function(Function::NativeFn(primitives::comparison::igt)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::igt)),
   );
   env.define(
     interner.get_or_intern(".<"),
-    Value::Function(Function::NativeFn(primitives::comparison::flt)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::flt)),
   );
   env.define(
     interner.get_or_intern(".<="),
-    Value::Function(Function::NativeFn(primitives::comparison::flte)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::flte)),
   );
   env.define(
     interner.get_or_intern(".>="),
-    Value::Function(Function::NativeFn(primitives::comparison::fgte)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::fgte)),
   );
   env.define(
     interner.get_or_intern(".>"),
-    Value::Function(Function::NativeFn(primitives::comparison::fgt)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::fgt)),
   );
   env.define(
     interner.get_or_intern("="),
-    Value::Function(Function::NativeFn(primitives::comparison::eq)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::eq)),
   );
   env.define(
     interner.get_or_intern("!="),
-    Value::Function(Function::NativeFn(primitives::comparison::ne)),
+    Value::Function(Function::NativeFn(None, primitives::comparison::ne)),
   );
   env.define(
     interner.get_or_intern("exit"),
-    Value::Function(Function::NativeFn(primitives::proc::exit)),
+    Value::Function(Function::NativeFn(None, primitives::proc::exit)),
   );
 
   env

--- a/backend/src/env/mod.rs
+++ b/backend/src/env/mod.rs
@@ -105,7 +105,7 @@ impl<S: Symbol> RTE<S> {
 
   pub fn extend(parent: Rc<RefCell<RTE<S>>>, values: Vec<Value<S>>) -> Rc<RefCell<Self>>  {
     Rc::new(RefCell::new(Self {
-      parent: Some(parent.clone()),
+      parent: Some(parent),
       values: values,
     }))
   }

--- a/backend/src/env/mod.rs
+++ b/backend/src/env/mod.rs
@@ -67,4 +67,82 @@ impl<S: Symbol> Env<S> {
       Err(symbol)
     }
   }
+
+  fn intern_lookup(&self, symbol: S, depth: i64) -> (i64, i64) {
+    if let Some(val) = self.values.get(&symbol) {
+      match val {
+        Value::Integer(val) => { (if let Some(_parent) = &self.parent {depth} else {-1}, *val) }
+        _ => {(-1, 1)}
+      }
+    }
+    else if let Some(parent) = &self.parent {
+      parent.borrow().intern_lookup(symbol, depth + 1)
+    }
+    else {
+      (-1, -1)
+    }
+  }
+  pub fn lookup(&self, symbol: S) -> (i64, i64) {
+    return self.intern_lookup(symbol, 0)
+  }
+  pub fn print(&self, msg: String) {
+   println!("{} cte {:p} {}", msg, self, self.values.len());
+  }
+}
+
+pub struct RTE<S: Symbol> {
+  parent: Option<Rc<RefCell<RTE<S>>>>,
+  values: Vec<Value<S>>,
+}
+
+impl<S: Symbol> RTE<S> {
+  pub fn new() -> Rc<RefCell<Self>> {
+    Rc::new(RefCell::new(Self {
+      parent: None,
+      values: Vec::new(),
+    }))
+  }
+
+  pub fn extend(parent: Rc<RefCell<RTE<S>>>, values: Vec<Value<S>>) -> Rc<RefCell<Self>>  {
+    Rc::new(RefCell::new(Self {
+      parent: Some(parent.clone()),
+      values: values,
+    }))
+  }
+
+  pub fn get(&self, depth: usize, index: usize) -> Option<Value<S>> {
+// self.print("get".to_string());
+    if depth == 0 {
+      return Some(self.values[index].clone());
+    }
+    else if let Some(parent) = &self.parent {
+// println!("Again {}", depth-1);
+      return parent.borrow().get(depth - 1, index)
+    } else {
+      return None
+    }
+  }
+
+  pub fn gimmithevaluespleaseatallcost(&mut self) -> Vec<Value<S>> {
+    let mut result: Vec<Value<S>> = Vec::with_capacity(self.values.len());
+    for val in &self.values { result.push(val.clone()) }
+    return result;
+  }
+
+  pub fn print(&self, msg: String) {
+   println!("{} rte {:p} {}", msg, self, self.values.len());
+  }
+
+  pub fn printall(&self, msg: String) {
+   println!("{} rte {:p} {}", msg, self, self.values.len());
+   if let Some(parent) = &self.parent {
+     print!("   parent: {:p}", parent.as_ref());
+     parent.borrow().print("   ".to_string());
+   }
+  }
+
+  pub fn format(&self) -> String {
+   return format!("rte {:p} {}", self, self.values.len())
+  }
+
 }

--- a/backend/src/env/mod.rs
+++ b/backend/src/env/mod.rs
@@ -123,6 +123,18 @@ impl<S: Symbol> RTE<S> {
     }
   }
 
+  pub fn set(&mut self, depth: usize, index: usize, value: Value<S>) -> bool {
+    if depth==0 {
+      self.values[index]=value;
+      return true
+    }
+    else if let Some(parent) = &self.parent {
+      return parent.borrow_mut().set(depth-1, index, value)
+    } else {
+      return false
+    }
+  }
+
   pub fn gimmithevaluespleaseatallcost(&mut self) -> Vec<Value<S>> {
     let mut result: Vec<Value<S>> = Vec::with_capacity(self.values.len());
     for val in &self.values { result.push(val.clone()) }

--- a/backend/src/env/primitives/comparison.rs
+++ b/backend/src/env/primitives/comparison.rs
@@ -225,6 +225,6 @@ pub fn ne<S: Symbol>(
   env: Rc<RefCell<Env<S>>>,
   args: Vec<Value<S>>,
 ) -> Result<Value<S>> {
-  let equal: bool = eq(env.clone(), args)?.try_into()?;
+  let equal: bool = eq(env, args)?.try_into()?;
   Ok(Value::Boolean(!equal))
 }

--- a/backend/src/interpreter/builtins.rs
+++ b/backend/src/interpreter/builtins.rs
@@ -123,7 +123,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
 
     let test_compiled = self.compile_expression(env.clone(), test.clone())?;
     let true_compiled = self.compile_expression(env.clone(), true_branch.clone())?;
-    let false_compiled = self.compile_expression(env.clone(), false_branch.clone())?;
+    let false_compiled = self.compile_expression(env, false_branch.clone())?;
 
     Ok(make_op_if(test_compiled, true_compiled, false_compiled))
 
@@ -143,7 +143,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
       param_names.push(param_name.as_symbol());
     }
 
-    let mut env = Env::extend(env.clone());
+    let mut env = Env::extend(env);
 
     /*
      for (name, arg) in std::iter::zip(lambda.params, args) {
@@ -154,7 +154,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
     let limit = param_names.len() as i64;
     while index < limit {
       let name = &param_names[index as usize];
-      env.define(name.clone(), Value::Integer(index));
+      env.define(*name, Value::Integer(index));
       index = index + 1;
     }
     let lambda = Function::Lambda(Lambda {
@@ -193,12 +193,12 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
       args.push(val);
     }
 
-    let mut inner_env = Env::extend(env.clone());
+    let mut inner_env = Env::extend(env);
     let mut index : i64 = 0;
     let limit = params.len() as i64;
     while index < limit {
       let name = &params[index as usize];
-      inner_env.define(name.clone(), Value::Integer(index));
+      inner_env.define(*name, Value::Integer(index));
       index = index + 1;
     }
     let code = self.compile_expression(Rc::new(RefCell::new(inner_env)), body.clone())?;

--- a/backend/src/interpreter/builtins.rs
+++ b/backend/src/interpreter/builtins.rs
@@ -157,7 +157,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
       env.define(name.clone(), Value::Integer(index));
       index = index + 1;
     }
-    let lambda = Function::Lambda(None, Lambda {
+    let lambda = Function::Lambda(Lambda {
       params: param_names,
       code: self.compile_expression(Rc::new(RefCell::new(env)), body.clone())?,
     });
@@ -203,7 +203,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
     }
     let code = self.compile_expression(Rc::new(RefCell::new(inner_env)), body.clone())?;
 
-    let lambda = Function::Lambda(None, Lambda {
+    let lambda = Function::Lambda(Lambda {
       params,
       code: code,
     });

--- a/backend/src/interpreter/builtins.rs
+++ b/backend/src/interpreter/builtins.rs
@@ -3,7 +3,7 @@ use lispers_common::{Backend, Symbol};
 
 use crate::prelude::*;
 use crate::data::{Value, Sym, List, Function, Lambda};
-use crate::env::{Env, RTE};
+use crate::env::{Env};
 use super::Interpreter;
 use super::{make_op_apply, make_op_if, make_op_enclose, make_op_println};
 
@@ -123,7 +123,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
 
     let test_compiled = self.compile_expression(env.clone(), test.clone())?;
     let true_compiled = self.compile_expression(env.clone(), true_branch.clone())?;
-    let false_compiled = self.compile_expression(env.clone(), false_branch.clone())?;
+    let false_compiled = self.compile_expression(env, false_branch.clone())?;
 
     Ok(make_op_if(test_compiled, true_compiled, false_compiled))
 
@@ -143,7 +143,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
       param_names.push(param_name.as_symbol());
     }
 
-    let mut env = Env::extend(env.clone());
+    let mut env = Env::extend(env);
 
     /*
      for (name, arg) in std::iter::zip(lambda.params, args) {
@@ -154,7 +154,7 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
     let limit = param_names.len() as i64;
     while index < limit {
       let name = &param_names[index as usize];
-      env.define(name.clone(), Value::Integer(index));
+      env.define(*name, Value::Integer(index));
       index = index + 1;
     }
     let lambda = Function::Lambda(Lambda {
@@ -193,12 +193,12 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
       args.push(val);
     }
 
-    let mut inner_env = Env::extend(env.clone());
+    let mut inner_env = Env::extend(env);
     let mut index : i64 = 0;
     let limit = params.len() as i64;
     while index < limit {
       let name = &params[index as usize];
-      inner_env.define(name.clone(), Value::Integer(index));
+      inner_env.define(*name, Value::Integer(index));
       index = index + 1;
     }
     let code = self.compile_expression(Rc::new(RefCell::new(inner_env)), body.clone())?;

--- a/backend/src/interpreter/mod.rs
+++ b/backend/src/interpreter/mod.rs
@@ -217,22 +217,19 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
       // println!("Op::Apply {:}", rte.borrow().format());
       let args_count = args.len();
       let mut val_args : Vec<Value<S>> = Vec::with_capacity(args_count);
-      let mut val_args_again : Vec<Value<S>> = Vec::with_capacity(args_count); // FIXME: can we remove this duplication?
 
       for arg in args {
          match self.exec_evaluation(gle.clone(), rte.clone(), &arg) {
-           Ok(arg) => {
-             val_args_again.push(arg.clone()); val_args.push(arg) }
+           Ok(arg) => { val_args.push(arg) }
            err => { return Done(err) }
          }
        }
 
        match self.exec_evaluation(gle.clone(), rte.clone(), &*op) {
          Ok(Value::Function(Function::NativeFn(irte, native_func))) => {
-          let rte = match irte { None => { rte }, Some(ref rte) => rte.clone() };
-          let _rte = RTE::extend(rte.clone(), val_args);
+          // let rte = match irte { None => { rte }, Some(ref rte) => rte.clone() };
 
-          match native_func(gle.clone(), val_args_again) {
+          match native_func(gle.clone(), val_args) {
             Ok(val) => { return Done(Ok(val)) }
             err => { return Done(err) }
           }

--- a/backend/src/interpreter/mod.rs
+++ b/backend/src/interpreter/mod.rs
@@ -4,27 +4,46 @@ use lispers_common::{StringInterner, Backend, Symbol};
 use lispers_frontend::{SExpression, Literal};
 use crate::prelude::*;
 use crate::data::{Value, List, Function};
-use crate::env::{Env, default_env};
+use crate::env::{Env, default_env, RTE};
 
 use crate::utils::assert_exactly_args;
-
-mod builtins;
 
 pub struct Interpreter<S: Symbol, B: Backend<S>> {
   interner: StringInterner<B>,
   marker: std::marker::PhantomData<S>,
 }
 
+// FIXME: last arg Vec<Value<S>> is actually unused!
+pub type RtArgs<S> = (Rc<RefCell<Env<S>>>, Rc<RefCell<RTE<S>>>, Op<S>);
+pub type RtThunk<S> = Promise<RtArgs<S>, Result<Value<S>>>;
+
+pub fn make_delay<S: Symbol>(gle: Rc<RefCell<Env<S>>>, rte: Rc<RefCell<RTE<S>>>, func: Op<S>) -> RtArgs<S> {
+  return (gle, rte, func)
+}
+
+mod builtins;
+
 impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
   pub fn new() -> Self {
+    let result =
     Self {
       interner: StringInterner::new(),
       marker: std::marker::PhantomData{},
-    }
+    };
+    return result
   }
 
   pub fn default_env(&mut self) -> Rc<RefCell<Env<S>>> {
-    Rc::new(RefCell::new(default_env(&mut self.interner)))
+    let result = Rc::new(RefCell::new(default_env(&mut self.interner)));
+    /*
+  PRINTLN(Vec<Op<S>>), // FIXME: can't get that to work properly
+    let func = move |rte, args| self.builtin_println_rt2(rte, args);
+    result.borrow().define(
+      self.interner.get_or_intern("println"),
+      Value::Function(Function::NativeFn(None, func)),
+    );
+    // */
+    return result
   }
 
   pub fn format_value(&self, value: &Value<S>) -> String {
@@ -46,11 +65,20 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
         format!("({})", repr)
       },
       Value::Function(func) => match func {
-        Function::NativeFn(native_func) => {
-          format!("[function {:p}]", native_func)
+        Function::NativeFn(rte, native_func) => {
+          // format!("[function {:p}]", native_func)
+          let env = match rte {
+            Some(rte) => { rte.borrow().format() }
+            _ => { "None".to_string() }
+          };
+          format!("[function native {:p} {:}]", native_func, env)
         },
-        Function::Lambda(lambda) => {
-          format!("[function {:p}]", lambda)
+        Function::Lambda(rte, lambda) => {
+          let env = match rte {
+            Some(rte) => { rte.borrow().format() }
+            _ => { "None".to_string() }
+          };
+          format!("[function {:p} code {:p} {:}]", lambda, lambda.code.as_ref(), env)
         },
       },
     }
@@ -86,17 +114,26 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
     Ok(last_result)
   }
 
-  pub fn eval_expression(
+  pub fn compile_expression(
     &mut self,
     env: Rc<RefCell<Env<S>>>,
     expression: Value<S>,
-  ) -> Result<Value<S>> {
+  ) -> Result<Op<S>> {
     match expression {
       Value::Symbol(sym) => {
         let sym = sym.as_symbol();
-        env.borrow().get(sym).ok_or_else(|| RuntimeError::UndefinedSymbol {
-          detail: self.interner.resolve(sym).unwrap_or("<>").to_string()
-        })
+        let (depth, index) = env.borrow().lookup(sym.clone());
+        if depth==-1 {
+          if index == -1 {
+            Err(RuntimeError::UndefinedSymbol {
+                detail: self.interner.resolve(sym).unwrap_or("<>").to_string()
+            })
+          } else {
+            Ok(Op::FetchGle(sym))
+          }
+        } else {
+          Ok(Op::RefRTE(depth as usize, index as usize))
+        }
       },
       Value::List(list) if !list.empty() => {
         let func = list.car()?;
@@ -108,62 +145,173 @@ impl<S: Symbol, B: Backend<S>> Interpreter<S, B> {
 
           match func_name {
             "println" => return self.builtin_println(env.clone(), args),
-            "quote" => return self.builtin_quote(args),
-            "def" => return self.builtin_define(env.clone(), args),
-            "set!" => return self.builtin_set(env.clone(), args),
-            "if" => return self.builtin_controlflow_if(env.clone(), args),
-            "lambda" => return self.builtin_lambda(args),
+            "quote" => return Ok(Op::Finish(self.builtin_quote(args)?)),
+            "def" => return Ok(Op::Finish(self.builtin_define(env.clone(), args)?)),
+            "set!" => return Ok(Op::Finish(self.builtin_set(env.clone(), args)?)),
+            "if" => return self.builtin_controlflow_if(env, args),
+            "lambda" => return self.builtin_lambda(env, args),
             "let" => return self.builtin_let_expression(env.clone(), args),
             _ => {},
           }
         }
 
-        let func = self.eval_expression(env.clone(), func)?;
-        let func: Function<S> = func.try_into()?;
+        let func = Box::new(self.compile_expression(env.clone(), func)?);
 
         let mut eval_args = Vec::with_capacity(args.len());
 
         for arg in args {
-          let arg = self.eval_expression(env.clone(), arg)?;
+          let arg = self.compile_expression(env.clone(), arg)?;
           eval_args.push(arg);
         }
 
-        self.eval_function(env.clone(), func, eval_args)
+        Ok(Op::Apply(func, eval_args))
       },
       _ => {
-        Ok(expression)
+        Ok(Op::Finish(expression))
       },
     }
   }
 
-  fn eval_function(
-    &mut self,
-    env: Rc<RefCell<Env<S>>>,
-    func: Function<S>,
-    args: Vec<Value<S>>,
-  ) -> Result<Value<S>> {
+  pub fn enclose(&mut self, rte: Rc<RefCell<RTE<S>>>, func: Function<S>) -> Value<S> {
+    // println!(" Enclose {:} ", rte.borrow().format());
     match func {
-      Function::NativeFn(func) => {
-        func(env.clone(), args)
-      },
-      Function::Lambda(lambda) => {
-        assert_exactly_args(lambda.params.len(), args.len())?;
+      Function::Lambda(_rte, lambda) => {
+        return Value::Function(Function::Lambda(Some(rte), lambda))
+      }
+      Function::NativeFn(_rte, native_func) => {
+        return Value::Function(Function::NativeFn(Some(rte), native_func))
+      }
+    }
+  }
 
-        let mut env = Env::extend(env.clone());
+  pub fn ret42(&mut self, content: RtArgs<S>) -> RtThunk<S> {
+  let (gle, rte, op) = content;
+  match op {
+    Op::RefRTE(depth, index) => {
+      // println!("RefRTE {:} depth {:} index {:}", rte.borrow().format(), depth, index);
+      if let Some(value) = rte.borrow().get(depth, index) {
+        return Done(Ok(value))
+      } else {
+        return Done(Err(RuntimeError::UndefinedSymbol{detail: "detail lost at runtime".to_string()} ))
+      }
+    }
+    Op::FetchGle(ref sym) => {
+      // println!("Op::FetchGle {:} sym {:}", rte.borrow().format(), self.interner.resolve(*sym).unwrap_or("<>").to_string());
+      return Done(gle.borrow().get(*sym).ok_or_else(|| RuntimeError::UndefinedSymbol {
+             detail: self.interner.resolve(*sym).unwrap_or("<>").to_string()
+             }))
+    }
+    Op::If(test, then, otherwise) => {
+      // println!("If {:} ", rte.borrow().format());
+      match self.exec_evaluation(gle.clone(), rte.clone(), test.as_ref()) {
+        Ok(Value::Boolean(val)) => {
+          if val {return Delay((gle, rte, *then))}
+          else {return Delay((gle, rte, *otherwise))}
+        }
+        Ok(_) => {return Delay((gle, rte, *then))}
+        other => Done(other)
+      }
+    }
+    Op::Enclose(func) => { return Done(Ok(self.enclose(rte, func))) }
+    Op::Apply(op, args) => {
+      // println!("Op::Apply {:}", rte.borrow().format());
+      let args_count = args.len();
+      let mut val_args : Vec<Value<S>> = Vec::with_capacity(args_count);
+      let mut val_args_again : Vec<Value<S>> = Vec::with_capacity(args_count); // FIXME: can we remove this duplication?
 
-        for (name, arg) in std::iter::zip(lambda.params, args) {
-          env.define(name, arg);
+      for arg in args {
+         match self.exec_evaluation(gle.clone(), rte.clone(), &arg) {
+           Ok(arg) => {
+             val_args_again.push(arg.clone()); val_args.push(arg) }
+           err => { return Done(err) }
+         }
+       }
+
+       match self.exec_evaluation(gle.clone(), rte.clone(), &*op) {
+         Ok(Value::Function(Function::NativeFn(irte, native_func))) => {
+          let rte = match irte { None => { rte }, Some(ref rte) => rte.clone() };
+          let _rte = RTE::extend(rte.clone(), val_args);
+
+          match native_func(gle.clone(), val_args_again) {
+            Ok(val) => { return Done(Ok(val)) }
+            err => { return Done(err) }
+          }
         }
 
-        self.eval_expression(
-          Rc::new(RefCell::new(env)),
-          lambda.body.as_ref().clone(),
-        )
-      },
+        Ok(Value::Function(Function::Lambda(ref irte, ref lambda))) => {
+          match assert_exactly_args(lambda.params.len(), args_count) {
+            Err(err) => { return Done(Err(err)) }
+            _ => {}
+          }
+          let rte = match irte {
+            None => {return Done(Err(RuntimeError::NYIE{detail: "should not happen 69".to_string()}))},
+            Some(ref rte) => rte.clone()
+          };
+          let rte = RTE::extend(rte.clone(), val_args);
+          Delay((gle, rte, *lambda.code.clone()))
+        }
+        Ok(value) => {
+          let func : Result<Function<S>> = value.try_into();
+          match func {
+            Err(err) => { return Done(Err(err)) }
+            Ok(_func) => {return Done(Err(RuntimeError::NYIE{detail: "ret42 strange case 69a".to_string()}))}
+          }
+        }
+        Err(err) => { return Done(Err(err)) }
+      }
     }
+    Op::Finish(val) => {
+      // println!("Op::Finish {:} => {}", rte.borrow().format(), self.format_value(&val));
+      return Done(Ok(val))
+    }
+    Op::PRINTLN(args) => { // FIXME: can't get that to work properly
+      // println!("Op::PRINTLN {:}", rte.borrow().format());
+      let args_count = args.len();
+      let mut val_args : Vec<Value<S>> = Vec::with_capacity(args_count);
+
+      for arg in args {
+         match self.exec_evaluation(gle.clone(), rte.clone(), &arg) {
+           Ok(arg) => { val_args.push(arg) }
+           err => { return Done(err) }
+         }
+      }
+
+      let output = val_args
+        .iter()
+        .map(|val| self.format_value(val))
+        .collect::<Vec<String>>()
+        .join(" ");
+
+      println!("{}", output);
+      Done(Ok(Value::default()))
+    }
+    // _ => {return Done(Err(RuntimeError::NYIE{detail: "ret42 Opcode".to_string()}))}
+    }
+  }
+
+  pub fn exec_evaluation(
+    &mut self,
+    global_env: Rc<RefCell<Env<S>>>,
+    env: Rc<RefCell<RTE<S>>>,
+    todo: &Op<S>
+  ) -> Result<Value<S>> {
+    let ret23 = |rt| self.ret42(rt);
+    return force_promise(ret23, make_delay(global_env, env, todo.clone()))
+  }
+
+  pub fn eval_expression(
+    &mut self,
+    env: Rc<RefCell<Env<S>>>,
+    expression: Value<S>,
+  ) -> Result<Value<S>> {
+    let todo = self.compile_expression(env.clone(), expression)?;
+// println!("running now");
+    let rte = RTE::new();
+    self.exec_evaluation(env, rte, &todo)
   }
 
   fn parse_sexpression(&self, sexpression: &SExpression<S>) -> Result<Value<S>> {
+    // FIXME: Am I just too new to rust or do we traverse the tree twice here?
     match sexpression {
       SExpression::Literal(val) => {
         Ok(self.parse_literal(val))

--- a/backend/src/prelude/mod.rs
+++ b/backend/src/prelude/mod.rs
@@ -100,14 +100,17 @@ pub use Promise::*;
 
 use super::data::{Value, Function};
 
-// use std::{rc::Rc}; // TBD: Should we use Rc over Box here?
+use std::{rc::Rc};
+
 #[derive(Clone)]
 pub enum Op<S: lispers_common::Symbol> {
   FetchGle(S), // read global variable
   RefRTE(usize, usize),
-  If(Box<Op<S>>, Box<Op<S>>, Box<Op<S>>),
+  If(Rc<Op<S>>, Rc<Op<S>>, Rc<Op<S>>),
   Finish(Value<S>),
   Enclose(Function<S>), // close over rte
-  Apply(Box<Op<S>>, Vec<Op<S>>),
-  PRINTLN(Vec<Op<S>>), // FIXME: can't get that to work properly
+  Apply(Rc<Op<S>>, Vec<Rc<Op<S>>>),
+  PRINTLN(Vec<Rc<Op<S>>>), // FIXME: can't get that to work properly
 }
+
+pub type RtOp<S> = Rc<Op<S>>;

--- a/backend/src/prelude/mod.rs
+++ b/backend/src/prelude/mod.rs
@@ -11,6 +11,7 @@ pub enum RuntimeError {
   TooFewArguments { expected: usize, got: usize },
   TooManyArguments { expected: usize, got: usize },
   TypeError { expected: String, got: String },
+  NYIE{ detail: String}
 }
 
 impl std::fmt::Display for RuntimeError {
@@ -47,6 +48,9 @@ impl std::fmt::Display for RuntimeError {
       Self::TypeError { expected, got } => {
         write!(f, "TypeError: expected <{}> but got <{}>", expected, got)
       }
+      Self::NYIE { detail }=> {
+        write!(f, "NYIE: {}", detail)
+      }
     }
   }
 }
@@ -67,4 +71,43 @@ impl From<SyntaxError> for RuntimeError {
   fn from(err: SyntaxError) -> Self {
     Self::SyntaxError(err)
   }
+}
+
+pub enum Promise<E, R> {
+  Delay(E),
+  Done(R)
+}
+
+#[inline(always)]
+pub fn force_promise<StepFn, E, R>(mut step: StepFn, mut expr: E) -> R
+where
+    StepFn: FnMut(E) -> Promise<E, R> // TBD: try FnMut here?
+{
+  loop {
+    match step(expr) {
+      Promise::Delay(tail) => {
+        expr = tail;
+        continue;
+      }
+      Promise::Done(result) => {
+        break result;
+      }
+    }
+  }
+}
+
+pub use Promise::*;
+
+use super::data::{Value, Function};
+
+// use std::{rc::Rc}; // TBD: Should we use Rc over Box here?
+#[derive(Clone)]
+pub enum Op<S: lispers_common::Symbol> {
+  FetchGle(S), // read global variable
+  RefRTE(usize, usize),
+  If(Box<Op<S>>, Box<Op<S>>, Box<Op<S>>),
+  Finish(Value<S>),
+  Enclose(Function<S>), // close over rte
+  Apply(Box<Op<S>>, Vec<Op<S>>),
+  PRINTLN(Vec<Op<S>>), // FIXME: can't get that to work properly
 }

--- a/backend/src/prelude/mod.rs
+++ b/backend/src/prelude/mod.rs
@@ -111,6 +111,8 @@ pub enum Op<S: lispers_common::Symbol> {
   Enclose(Function<S>), // close over rte
   Apply(Rc<Op<S>>, Vec<Rc<Op<S>>>),
   PRINTLN(Vec<Rc<Op<S>>>), // FIXME: can't get that to work properly
+
+  AssignLex(usize, usize, Rc<Op<S>>),
 }
 
 pub type RtOp<S> = Rc<Op<S>>;


### PR DESCRIPTION
This is probably rather bad Rust code. It is the first time I ever did anything practical with rust.

In order to learn rust I wanted to do the logical next steps for an educational lisp implementation: make it tail recursive an split compile time code analysis from runtime.

So far things seem to work at least. Except for "set!" which should not be too hard and comming one day.

Speed is disappointing.

Some code cleanup is still to be done.

Open Questions:

1) I wonder: likely I should understand when to use Rc vs. Box; I guess there is useless copying going on.

2) The Op::PRINTLN is a work around to just make it work some way. It should be exported as NativeFn. For this I would need to create a closure and define it. Grep for "FIXME: can't get that to work properly" to find my failed attempts.

3) I would actually rather like to be able to declare a version on NativeFn which is FnMut(). Can't figure out how. Any help appreciated.